### PR TITLE
Update setFooter to use object parameter

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -130,7 +130,7 @@ function createEmbed(
     .setColor(color)
     .setTitle(`${title}`)
     .setDescription(monotype ? `\`\`\`yaml\n${content}\n\`\`\`` : `${content}`)
-    .setFooter(`${footer}`, footerImageURL);
+    .setFooter({ text: `${footer}`, iconURL: footerImageURL });
 }
 
 module.exports = {


### PR DESCRIPTION
<!-- Thanks for taking the time to work on a patch! Please fill in the following. -->
<!-- We'll be in touch if we need any other information. -->
<!-- Once submitted, follow this PR's progress on the project board. -->
<!-- Notes like this are comments and won't appear in the PR. -->

**Related bugs/feature requests**
<!-- e.g. Resolves #2 -->
<!-- e.g. Resolves devcodeabode/BADI-bot#23 -->
<!-- New bullet point for each issue if there's more than one. -->
+ Resolves  #18 

**Describe the changes**
<!-- A clear, concise description of the changes. -->
Updates the utility `setFooter` function to use an object to set footer details instead of the deprecated two separate parameters.

**Expected behavior**
<!-- A clear, concise description of what you expect to happen. -->
No change in behavior.

**Screenshots**
<!-- If applicable, add screenshots to help explain your fix. -->

**New npm dependencies**
<!-- If there are new npm dependencies, list them below with their versions -->
<!-- Make sure changes to package.json and package-lock.json are committed as well -->

**Testing Instructions**
<!-- Instructions to thoroughly test this patch. -->

1. On line 169 of `main.js` (when a DM is received), replace the reply that exists with a new one that contains an embed:
```js
utils.reply(
      utils.createEmbed(
        "Title",
        "Content",
        false,
        "Footer Text",
        message.author.avatarURL()
      ),
      message
    );
```
2. Start the bot.
3. Send the bot a DM. Verify that it replies with a correctly formed embed.
4. Remove the parameter for the footer image and restart the bot.
5. Send the bot another DM. Verify that it replies with a correctly formed embed with no logged errors.

**Additional context**
<!-- Add any other context about the PR here. -->
